### PR TITLE
Add Cluster DNS suffix validation prior to calling HCI cluster registration step

### DIFF
--- a/scripts/OneNode.ps1
+++ b/scripts/OneNode.ps1
@@ -465,6 +465,17 @@ function RegisterHciCluster
     $session = New-PSSession -EnableNetworkAccess
     Invoke-Command -Session $session -ScriptBlock `
     {
+        function Get-ClusterDNSSuffix{
+            $clusterNameResourceGUID = (Get-ItemProperty -Path HKLM:\Cluster -Name ClusterNameResource).ClusterNameResource 
+            $clusterDNSSuffix =  (Get-ClusterResource $clusterNameResourceGUID | Get-ClusterParameter DnsSuffix).Value 
+            return $clusterDNSSuffix
+          }
+
+        # Verify Cluster has DNS suffix set
+        Write-Verbose "Performing simple validation that DNS suffix exists for cluster"
+        $dnsSuffix = Get-ClusterDNSSuffix
+        if (!$dnsSuffix) { Write-Error "DNS suffix not set for cluster, registration cannot proceed without DNS suffix. Please fix this before continuing." }
+
         #Connect to Azure inside this new session
         $spnSecStr = ConvertTo-SecureString -String $using:spnClientSecret -AsPlainText -Force
         $spnCredObj = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $using:spnClientId, $spnSecStr


### PR DESCRIPTION
Currently RegisterHCICluster function internally invokes Register-AzStackHCI function, and this call fails if the Cluster DNS Suffix is not set. Currently the failure message does not indicate that the failure is due to Cluster DNS Suffix not existing. This PR add validation for Cluster DNS suffix being present in RegisterHCICluster function itself, and appropriate error message is returned if suffix does not exist.